### PR TITLE
担当箇所のレイアウト修正、レスポンシブ対応／その他修正

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,4 +1,6 @@
 class Admin::ItemsController < ApplicationController
+  before_action :authenticate_admin!
+  
   def index
     @items = Item.page(params[:page])
   end

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,4 +1,5 @@
 class Admin::MembersController < ApplicationController
+  before_action :authenticate_admin!
 
   def show
     @member = Member.find(params[:id])

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,7 +1,8 @@
 class Admin::SearchesController < ApplicationController
+  before_action :authenticate_admin!
 
   def items_search
-    # @genres = Genre.all
-    @items = Item.looks(params[:search], params[:word]).page(params[:page])
+    @items = Item.looks(params[:search], params[:word], true).page(params[:page])
   end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,8 +15,10 @@ class Item < ApplicationRecord
     (self.price * 1.08).round
   end
 
-  def self.looks(search, word)
-    @item = Item.where("is_active = ? AND name LIKE ?", true, "%#{word}%")
+  def self.looks(search, word, include_inactive = false)
+    items = where("name LIKE ?", "%#{word}%")
+    items = items.where(is_active: true) unless include_inactive
+    items
   end
 
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -16,5 +16,5 @@ class Member < ApplicationRecord
   validates :email,             presence: true, uniqueness: true
   validates :post_code,         presence: true, length: {is: 7},  numericality: {only_integer: true}
   validates :address,           presence: true, length: {maximum: 50}
-  validates :telephone_number,  presence: true, length: {is: 11}, numericality: {only_integer: true}
+  validates :telephone_number,  presence: true, length: {in: 10..11}, numericality: {only_integer: true}
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,17 +1,21 @@
 <%= render 'admin/shared/header.html.erb' %>
 <div class="container p-3">
-  <div class="row">
-    <div class="col-md-12">
-      <h3 class="ml-5 my-5">ジャンル編集</h3>
-      <div class="form-group">
-        <%= form_with model: @genre, url:admin_genre_path, method: :patch do |f| %>
-          <%= f.label "ジャンル名" %>
-          <div class="d-flex">
-          <%= f.text_field :name, class: "form-control mr-3 w-50" %>
-          <%=f.submit "変更を保存", class:"btn btn-success" %>
-          </div>
-        <% end %>
-      </div>
-    </div>
+  <div class="col-md-12 mb-3 mt-3">
+    <h3>ジャンル編集</h3>
   </div>
+
+  <%= form_with model: @genre, url:admin_genre_path, method: :patch do |f| %>
+  <div class="row">
+    <div class="col-md-2">
+      <%= f.label :name, "ジャンル名" %>
+    </div>
+    <div class="col-md-4">
+      <%= f.text_field :name, class: "form-control mb-1" %>
+    </div>
+    <div class="col-md-2">
+      <%=f.submit "変更を保存", class:"btn btn-success" %>
+    </div>
+    <div class="offset-md-4"></div>
+  </div>
+  <% end %>
 </div>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,39 +1,41 @@
 <%= render 'admin/shared/header.html.erb' %>
 <div class="container p-3">
-  <div class="row">
-    <div class="col-md-12">
+  <div class="col-md-12 mb-3 mt-3">
+    <h3>ジャンル 一覧・追加</h3>
+  </div>
 
-      <h3 class="my-5 ml-5" >ジャンル 一覧・追加</h3>
-      <%= render "admin/shared/error_messages", resource: @genre %>
-      <div class="row">
-        <div class="col-8">
-          <%= form_with model: @genre,url: admin_genres_path, "data-turbolinks": false  do |f| %>
-            <%= f.label :name, "ジャンル名" %>
-            <div class="d-flex">
-            <%= f.text_field :name, placeholder: "ジャンル名", class: "form-control w-50 mr-3" %>
-            <%= f.submit "新規登録", class:"btn btn-success" %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <div class="row">
-        <div class=col-6 >
-          <table class='table mt-5'>
-            <thead>
-              <tr>
-                <th>ジャンル</th>
-                <th colspan="2"></th>
-              </tr>
-            </thead>
-            <% @genres.each do |genre| %>
-            <tbody>
-              <th><%= genre.name %></th>
-              <th><%= link_to "編集する", edit_admin_genre_path(genre), class:"btn btn-success" %></th>
-            </tbody>
-            <% end %>
-          </table>
-        </div>
-      </div>
+  <%= form_with model: @genre,url: admin_genres_path, "data-turbolinks": false  do |f| %>
+  <div class="row">
+    <div class="col-md-2">
+      <%= f.label :name, "ジャンル名" %>
     </div>
+    <div class="col-md-4">
+      <%= f.text_field :name, placeholder: "ジャンル名", class: "form-control mb-1" %>
+    </div>
+    <div class="col-md-2">
+      <%= f.submit "新規登録", class:"btn btn-success" %>
+    </div>
+    <div class="offset-md-4"></div>
+  </div>
+  <% end %>
+
+  <div class="row">
+    <div class="col-md-6 mt-3">
+      <table class="table">
+        <tr class="table-secondary">
+          <th>ジャンル</th>
+          <th colspan="2"></th>
+        </tr>
+        <% @genres.each do |genre| %>
+        <tr>
+          <td><%= genre.name %></td>
+          <td>
+            <%= link_to "編集する", edit_admin_genre_path(genre), class:"btn btn-success" %>
+          </td>
+        </tr>
+        <% end %>
+      </table>
+    </div>
+    <div class="offset-md-6"></div>
   </div>
 </div>

--- a/app/views/admin/shared/_search.html.erb
+++ b/app/views/admin/shared/_search.html.erb
@@ -1,4 +1,3 @@
-
 <div class="clearfix">
   <div class="form-inline float-right">
     <%= form_with url: admin_items_search_path, local: true, method: :get do |f| %>

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -9,68 +9,105 @@
       <p class="mb-5">こちらから会員登録を行ってください。</p>
 
       <div class="bg-white py-4 mx-auto w-100">
-          <%= form_with model: @member, url: member_registration_path do |f| %>
 
-        <table class="table table-borderless">
-          <tr>
-            <td class="text-right">名前</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.text_field :family_name, autofocus: true, placeholder: "令和", class: "mr-1 w-75 form-control" %></td>
-            <td><%= f.text_field :first_name, placeholder: "道子", class: "w-75 form-control" %></td>
-          </tr>
+        <div class="row">
+          <div class="col-md-3">
+            氏名<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
 
-          <tr>
-            <td class="text-right">フリガナ</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.text_field :family_name_kana, placeholder: "レイワ", class: "w-75 form-control" %></td>
-            <td><%= f.text_field :first_name_kana, placeholder: "ミチコ", class: "w-75 form-control" %></td>
-          </tr>
+          <div class="col-md-4">
+            <%= form_with model:@member, url: member_registration_path do |f| %>
+            <%= f.text_field :family_name, autofocus: true, placeholder: "令和", class: "form-control mt-1" %>
+          </div>
 
-          <tr>
-            <td class="text-right">メールアドレス</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.text_field :email, placeholder: "sample@example.com", class: "w-75 form-control" %></td>
-          </tr>
+          <div class="col-md-4">
+            <%= f.text_field :first_name, placeholder: "道子", class: "form-control mt-1" %>
+          </div>
 
-          <tr>
-            <td class="text-right">郵便番号(ハイフンなし)</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.text_field :post_code, placeholder: "0000000", class: "w-75 form-control" %></td>
-          </tr>
+          <div class="offset-md-1"></div>
 
-          <tr>
-            <td class="text-right">住所</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.text_field :address, placeholder: "東京都渋谷区代々木神園町0-0", class: "w-100 form-control" %></td>
-          </tr>
+          <div class="col-md-3 mt-3">
+            フリガナ<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
 
-          <tr>
-            <td class="text-right">電話番号(ハイフンなし)</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.text_field :telephone_number, placeholder: "00000000000", class: "w-75 form-control" %></td>
-          </tr>
+          <div class="col-md-4">
+            <%= f.text_field :family_name_kana, placeholder: "レイワ", class: "form-control mt-1" %>
+          </div>
 
-          <tr>
-            <td class="text-right">パスワード
-              <% if @minimum_password_length %>
-                (<%= @minimum_password_length %> 文字以上)
-              <% end %>
-            </td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.password_field :password, class: "w-75 form-control" %></td>
-          </tr>
-          <tr>
-            <td class="text-right">パスワード(確認用)</td>
-            <td><span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span></td>
-            <td><%= f.password_field :password_confirmation, class: "w-75 form-control" %></td>
-          </tr>
-        </table>
+          <div class="col-md-4">
+            <%= f.text_field :first_name_kana, placeholder: "ミチコ", class: "form-control mt-1" %>
+          </div>
 
-        <div class="text-center">
-          <%= f.submit "新規登録", class:"btn rounded-pill necessary-field text-light px-3 mt-4" %></td>
+          <div class="offset-md-1"></div>
+
+          <div class="col-md-3 mt-3">
+            メールアドレス<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
+
+          <div class="col-md-4">
+            <%= f.text_field :email, placeholder: "sample@example.com", class: "w-100 form-control mt-1" %>
+          </div>
+
+          <div class="offset-md-5"></div>
+
+          <div class="col-md-3 mt-3">
+            郵便番号(ハイフンなし)<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
+
+          <div class="col-md-4">
+            <%= f.text_field :post_code, placeholder: "0000000", class: "form-control mt-1" %>
+          </div>
+
+          <div class="offset-md-5"></div>
+
+          <div class="col-md-3 mt-3">
+            住所<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
+
+          <div class="col-md-8">
+            <%= f.text_field :address, placeholder: "東京都渋谷区代々木神園町0-0", class: "w-100 form-control mt-1" %>
+          </div>
+
+          <div class="offset-md-1"></div>
+
+          <div class="col-md-3 mt-3">
+            電話番号(ハイフンなし)<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
+
+          <div class="col-md-4">
+            <%= f.text_field :telephone_number, placeholder: "0000000000", class: "form-control mt-1" %>
+          </div>
+
+          <div class="offset-md-5"></div>
+
+          <div class="col-md-3 mt-3">
+            パスワード<% if @minimum_password_length %>
+                        (<%= @minimum_password_length %> 文字以上)
+                      <% end %>
+            <span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
+
+          <div class="col-md-4">
+            <%= f.password_field :password, class: "form-control mt-1" %>
+          </div>
+
+          <div class="offset-md-5"></div>
+
+          <div class="col-md-3 mt-3">
+            パスワード(確認用)<span class="text-light necessary-field p-1 px-2 ml-2 small rounded">必須</span>
+          </div>
+
+          <div class="col-md-4">
+            <%= f.password_field :password_confirmation, class: "form-control mt-1" %>
+          </div>
+
+          <div class="offset-md-5"></div>
+
         </div>
-
-      <% end %>
+        <div class="text-center">
+          <%= f.submit "新規登録", class:"btn rounded-pill necessary-field text-light px-3 mt-4" %>
+            <% end %>
+        </div>
       </div>
 
       <div>
@@ -80,8 +117,6 @@
           <%= link_to "こちら", new_member_session_path, class: "btn text-light rounded-pill necessary-field px-4 mb-5", 'data-turbolinks': false %>
         </div>
       </div>
-
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
・会員登録画面のレイアウト変更とレスポンシブ対応
・ジャンル一覧／登録、編集画面のレイアウト変更とレスポンシブ対応
・管理者非ログイン時に管理者側ページへ飛べないように変更
・管理者側のアイテム検索は販売停止中の商品もヒットするように変更
・会員登録の際の電話番号の桁数を10~11の間に変更（固定電話でも登録できるよう）

ご確認よろしくお願いします！


